### PR TITLE
Extended app context to utilize an api manager which allows DI in specs

### DIFF
--- a/RefactorExample.xcodeproj/project.pbxproj
+++ b/RefactorExample.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		5771C7061FA77029003F53B9 /* TrialEpisodeViewModelSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5771C7051FA77029003F53B9 /* TrialEpisodeViewModelSpec.swift */; };
 		5771C7081FA7708C003F53B9 /* Nimble.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 5771C7001FA7700F003F53B9 /* Nimble.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		5771C7091FA7708C003F53B9 /* Quick.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 5771C7011FA7700F003F53B9 /* Quick.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		C91B54391FA79276000E2F65 /* APIManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C91B54381FA79276000E2F65 /* APIManager.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -69,6 +70,7 @@
 		5771C7011FA7700F003F53B9 /* Quick.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Quick.framework; path = Carthage/Build/iOS/Quick.framework; sourceTree = "<group>"; };
 		5771C7041FA77028003F53B9 /* RefactorExampleTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "RefactorExampleTests-Bridging-Header.h"; sourceTree = "<group>"; };
 		5771C7051FA77029003F53B9 /* TrialEpisodeViewModelSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrialEpisodeViewModelSpec.swift; sourceTree = "<group>"; };
+		C91B54381FA79276000E2F65 /* APIManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIManager.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -125,6 +127,7 @@
 				5771C6F91FA76ECC003F53B9 /* ServiceError.swift */,
 				5771C6FB1FA76EE0003F53B9 /* MyAppDelegate.swift */,
 				5771C6FD1FA76EF2003F53B9 /* AppContext.swift */,
+				C91B54381FA79276000E2F65 /* APIManager.swift */,
 			);
 			path = RefactorExample;
 			sourceTree = "<group>";
@@ -248,6 +251,7 @@
 				5771C6FA1FA76ECC003F53B9 /* ServiceError.swift in Sources */,
 				5771C6FE1FA76EF2003F53B9 /* AppContext.swift in Sources */,
 				5771C6D61FA76BD7003F53B9 /* ViewController.swift in Sources */,
+				C91B54391FA79276000E2F65 /* APIManager.swift in Sources */,
 				5771C6D41FA76BD7003F53B9 /* AppDelegate.swift in Sources */,
 				5771C6FC1FA76EE0003F53B9 /* MyAppDelegate.swift in Sources */,
 				5771C6F61FA76EA2003F53B9 /* TrialEpisodeViewModelDelegate.swift in Sources */,

--- a/RefactorExample/APIManager.swift
+++ b/RefactorExample/APIManager.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+protocol APICallable {
+    func getVideo(_ guid: String, onSuccess: (Video) -> Void, onFailure: (ServiceError) -> Void)
+}
+
+class APIManager: APICallable {
+    func getVideo(_ guid: String, onSuccess: (Video) -> Void, onFailure: (ServiceError) -> Void) {
+        let exampleVideo = Video(title: "someTitle", guid: "someGuid")
+        if exampleVideo.guid == guid {
+            onSuccess(exampleVideo)
+        }
+        else {
+            onFailure(.someError)
+        }
+    }
+}

--- a/RefactorExample/AppContext.swift
+++ b/RefactorExample/AppContext.swift
@@ -1,4 +1,7 @@
+protocol ShareableContext {
+    var apiManager: APICallable { get }
+}
 
-class AppContext {
-    
+class AppContext: ShareableContext {
+    var apiManager: APICallable = APIManager()
 }

--- a/RefactorExample/MyAppDelegate.swift
+++ b/RefactorExample/MyAppDelegate.swift
@@ -1,4 +1,3 @@
-
 class MyAppDelegate {
-    static let sharedAppContext = AppContext()
+    static let sharedAppContext: ShareableContext = AppContext()
 }

--- a/RefactorExample/TrialEpisodeViewModel.swift
+++ b/RefactorExample/TrialEpisodeViewModel.swift
@@ -6,16 +6,14 @@ class TrialEpisodeViewModel {
     
     weak var delegate: TrialEpisodeViewModelDelegate?
     
-    func loadModel(_ videoGuid: String) {
+    func loadModel(_ videoGuid: String, appContext: ShareableContext) {
         self.videoGuid = videoGuid
         
-        Video.videoFor(guid: videoGuid, appContext: MyAppDelegate.sharedAppContext,
-                       onSuccess: { [weak self] video in
-                        self?.video = video
-                        self?.delegate?.didCompleteLoad(video)
-            },
-                       onFailure: { [weak self] error in
-                        self?.delegate?.didFailToLoad(error)
+        appContext.apiManager.getVideo(videoGuid, onSuccess: { [weak self] video in
+            self?.video = video
+            self?.delegate?.didCompleteLoad(video)
+        }, onFailure: { [weak self] error in
+            self?.delegate?.didFailToLoad(error)
         })
     }
 }

--- a/RefactorExample/Video.swift
+++ b/RefactorExample/Video.swift
@@ -7,20 +7,4 @@ class Video {
         self.title = title
         self.guid = guid
     }
-    
-    static func videoFor(
-        guid: String,
-        appContext: AppContext,
-        onSuccess: (Video) -> Void,
-        onFailure: (ServiceError) -> Void)  {
-        
-        let exampleVideo = Video(title: "someTitle", guid: "someGuid")
-        
-        if exampleVideo.guid == guid {
-            onSuccess(exampleVideo)
-        }
-        else {
-            onFailure(.someError)
-        }
-    }
 }

--- a/RefactorExampleTests/TrialEpisodeViewModelSpec.swift
+++ b/RefactorExampleTests/TrialEpisodeViewModelSpec.swift
@@ -1,12 +1,72 @@
 import Quick
 import Nimble
+@testable import RefactorExample
+
+// MARK: Mocking classes
+
+var mockShouldReturnSuccess = false
+
+class AppContextMock: ShareableContext {
+    var apiManager: APICallable = APIManagerMock()
+}
+
+class APIManagerMock: APICallable {
+    func getVideo(_ guid: String, onSuccess: (Video) -> Void, onFailure: (ServiceError) -> Void) {
+        let exampleVideo = Video(title: "someTitle", guid: "someGuid")
+        if mockShouldReturnSuccess {
+            onSuccess(exampleVideo)
+        } else {
+            onFailure(.someError)
+        }
+    }
+}
+
+class TrialEpisodeViewModelDelegateStub: NSObject, TrialEpisodeViewModelDelegate {
+    var didCompleteLoadCalled = false
+    var didFailToLoadCalled = false
+    
+    func didCompleteLoad(_ video: Video) {
+        didCompleteLoadCalled = true
+    }
+    
+    func didFailToLoad(_ error: ServiceError) {
+        didFailToLoadCalled = true
+    }
+}
+
+// MARK: Main tests
 
 class TrialEpisodeViewModelSpec : QuickSpec {
+    
     override func spec() {
         describe("TrialEpisodeViewModel") {
-            it("hey") {
-                expect(1).to(equal(1))
+            let videoGUID = "123xyz"
+            var trialEpisodeVM = TrialEpisodeViewModel()
+            var delegateStub = TrialEpisodeViewModelDelegateStub()
+            let contextMock = AppContextMock()
+            
+            beforeEach {
+                trialEpisodeVM = TrialEpisodeViewModel()
+                delegateStub = TrialEpisodeViewModelDelegateStub()
+                trialEpisodeVM.delegate = delegateStub
             }
+            
+            context("onSuccess", closure: {
+                it("delegate will recieve didCompleteLoad") {
+                    mockShouldReturnSuccess = true
+                    trialEpisodeVM.loadModel(videoGUID, appContext: contextMock)
+                    expect(delegateStub.didCompleteLoadCalled).to(equal(true))
+                }
+            })
+            
+            context("onFailure", closure: {
+                it("delegate will recieve didFailToLoad with an error") {
+                    mockShouldReturnSuccess = false
+                    trialEpisodeVM.loadModel(videoGUID, appContext: contextMock)
+                    expect(delegateStub.didFailToLoadCalled).to(equal(true))
+                }
+            })
+            
         }
     }
 }


### PR DESCRIPTION
Hi Kirmanie,

Here is the refactored specs to account for an external call to fetch a video. Main points to note:

- I removed the static call to fetch the video in the Video model. I usually like to take the stance of leaving models with only original data representation. Any data manipulation I like to put into a View Model and any hydration I like to use a Service or Manager. This way the model just mirrors the data in a storage container such as **realm** or **core data** and thats all.

- I added in a `APIManager` class which conforms to the `APICallable` protocol. By leaning on protocols it makes it much easier to create mocks in the test cases.

- Added mocks for `AppContext` and `APIManager` to the specs and used a global flag to determine if a success or failure should be returned from the external api call. 

I appreciate your time today and am excited for the chance to assist you guys in refactoring your code base into a Tesla from the model T. 🤣

Best,
Matt